### PR TITLE
Hapus method tidak terpakai di BaseModule & perbaikan RouteServiceProvider modul

### DIFF
--- a/src/Base/BaseModule.php
+++ b/src/Base/BaseModule.php
@@ -36,10 +36,6 @@ abstract class BaseModule
         return [];
     }
 
-    public function defaultModuleAction(): void
-    {
-    }
-
     public function isDefault(): bool
     {
         return $this->default;

--- a/src/stubs/RouteServiceProvider.stub
+++ b/src/stubs/RouteServiceProvider.stub
@@ -15,15 +15,18 @@ class RouteServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        if (Module::get($this->module_name)->isDefault())
-             Route::middleware('web')->get('/', [BaseController::class, 'index']);
+        $this->routes(function() {
+            if (Module::get($this->module_name)->isDefault()) {
+                Route::middleware('web')->get('/', [BaseController::class, 'index']);
+            }
 
-        Route::prefix('api/' . $this->prefix)
-            ->middleware('api')
-            ->group(__DIR__ . '/' . $this->route_path . '/api.php');
+            Route::prefix('api/' . $this->prefix)
+                ->middleware('api')
+                ->group(__DIR__ . '/' . $this->route_path . '/api.php');
 
-        Route::middleware('web')
-            ->prefix("{$this->prefix}")
-            ->group(__DIR__ . '/' . $this->route_path . '/web.php');
+            Route::middleware('web')
+                ->prefix("{$this->prefix}")
+                ->group(__DIR__ . '/' . $this->route_path . '/web.php');
+        });
     }
 }


### PR DESCRIPTION
Method `defaultModuleAction()` dari `BaseModule` sudah tidak terpakai sejak commit 7b6f8fd0fda15e3b930179e7b66e6ea7fe58ee66. Default action dari setiap modul sekarang diatur di `RouteServiceProvider` setiap modul agar dapat di-cache.

Route yang didaftarkan di `RouteServiceProvider` setiap modul harus dimasukkan ke dalam _closure_ melalui `\Illuminate\Foundation\Support\Providers\RouteServiceProvider::routes()` agar dapat di-cache.