### PR TITLE
Bump PHP version to ^8.0 and Laravel to ^9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
-/vendor
+composer.lock
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "dptsi/laravel-modular",
   "description": "Laravel modular template developed for DPTSI projects",
   "type": "library",
-
   "authors": [
     {
       "name": "DPTSI ITS",
@@ -11,9 +10,9 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": "^7.4|8.0.*",
+    "php": "^8.0.2",
     "ext-pdo": "*",
-    "laravel/framework": "^8.12"
+    "laravel/framework": "^8.12|^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Laravel Upgrade Guide Checklist (v8.0 to v9.0) (https://laravel.com/docs/9.x/upgrade):

- [x] Updating Dependencies
  - [x] PHP 8.0.2 requirement
  - [x] `laravel/framework` version bump

Lang directory changes does not affect the library -- we directly use Service Provider for this